### PR TITLE
[README] Add GitPOAP Badge to Display Number of Minted GitPOAPs for Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # ethsta_staking_analysis
+[![gitpoap badge](https://public-api.gitpoap.io/v1/repo/Zachary-Lingle/ethsta_staking_analysis/badge)](https://www.gitpoap.io/gh/Zachary-Lingle/ethsta_staking_analysis)
+
 This repository conducts data analytics on Ethereum staking pools, aka the entities that control the validators of the beacon chain. See our post on [ethresear.ch](https://ethresear.ch/t/open-source-data-analytics-of-ethereum-staking-pools/12348) for more details.
 ## Getting started
 ### Prerequisites


### PR DESCRIPTION
Hey all, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie